### PR TITLE
fix: handle edge case correctly

### DIFF
--- a/workflow/scripts/artifact_annotation.py
+++ b/workflow/scripts/artifact_annotation.py
@@ -110,7 +110,7 @@ def add_artifact_annotation_data(in_vcf_filename, artifacts, out_vcf_filename):
             if sd == "0":
                 nrsd = 1000
             elif float(sd) == 1000.0 or float(sd) == 0.0:
-                if float(Medians[i]) > AF:
+                if float(Medians[i]) >= AF:
                     nrsd = 0.0
                 else:
                     nrsd = 1000


### PR DESCRIPTION
When the artifact filter has 0 standard deviation and the median is the same as the AF the variant should be filtered. This happens only if AF is 100%.