### PR TITLE
fix: the generated multivariant codon now also outputs AF in info field

### DIFF
--- a/workflow/scripts/add_multi_snv_in_codon.py
+++ b/workflow/scripts/add_multi_snv_in_codon.py
@@ -244,7 +244,7 @@ def add_multi_snv_in_codon(in_fastq_ref, in_vcf, out_vcf, af_limit, artifact_lim
                 alt_AA = AA
         aa_nr = int(math.ceil(gene_pos / 3.0))
         out_vcf.write(chrom + "\t" + str(pos) + "\t.\t" + "".join(ref) + "\t" + "".join(alt) + "\t.\tPASS\t")
-        out_vcf.write("Artifact=-1")
+        out_vcf.write("AF=" + str(AF_min) + ";Artifact=-1")
         i = 0
         while i < nr_callers:
             out_vcf.write(",-1")


### PR DESCRIPTION
The Hotspot report that generate the in-silico reports for the clinical geneticists in WP1 relies on the AF value in the INFO field of the vcf and not the FORMAT field. This PR simply adds the AF also to the INFO field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * VCF records for constructed multi-nucleotide variants now include the minimum allele frequency in the INFO field, in addition to the existing artifact flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->